### PR TITLE
Fix Option fields in IndexedCheckpoint

### DIFF
--- a/crates/sui-indexer/src/models/raw_checkpoints.rs
+++ b/crates/sui-indexer/src/models/raw_checkpoints.rs
@@ -19,8 +19,8 @@ impl From<&IndexedCheckpoint> for StoredRawCheckpoint {
     fn from(c: &IndexedCheckpoint) -> Self {
         Self {
             sequence_number: c.sequence_number as i64,
-            certified_checkpoint: bcs::to_bytes(c.certified_checkpoint.as_ref().unwrap()).unwrap(),
-            checkpoint_contents: bcs::to_bytes(c.checkpoint_contents.as_ref().unwrap()).unwrap(),
+            certified_checkpoint: bcs::to_bytes(&c.certified_checkpoint).unwrap(),
+            checkpoint_contents: bcs::to_bytes(&c.checkpoint_contents).unwrap(),
         }
     }
 }

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -27,7 +27,7 @@ use crate::errors::IndexerError;
 
 pub type IndexerResult<T> = Result<T, IndexerError>;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct IndexedCheckpoint {
     // TODO: A lot of fields are now redundant with certified_checkpoint and checkpoint_contents.
     pub sequence_number: u64,
@@ -49,9 +49,10 @@ pub struct IndexedCheckpoint {
     pub end_of_epoch: bool,
     pub min_tx_sequence_number: u64,
     pub max_tx_sequence_number: u64,
-    // FIXME: Remove the Default derive and make these fields mandatory.
-    pub certified_checkpoint: Option<CertifiedCheckpointSummary>,
-    pub checkpoint_contents: Option<CheckpointContents>,
+    /// The certified checkpoint summary for this checkpoint.
+    pub certified_checkpoint: CertifiedCheckpointSummary,
+    /// The full checkpoint contents.
+    pub checkpoint_contents: CheckpointContents,
 }
 
 impl IndexedCheckpoint {
@@ -90,8 +91,8 @@ impl IndexedCheckpoint {
             checkpoint_commitments: checkpoint.checkpoint_commitments.clone(),
             min_tx_sequence_number,
             max_tx_sequence_number,
-            certified_checkpoint: Some(checkpoint.clone()),
-            checkpoint_contents: Some(contents.clone()),
+            certified_checkpoint: checkpoint.clone(),
+            checkpoint_contents: contents.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove `Default` derive and Option types from `IndexedCheckpoint`
- update `from_sui_checkpoint` and storage conversion

## Testing
- `cargo fmt --all` *(fails: unsuccessful tunnel)*
- `cargo test -p sui-indexer --no-run` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_b_684a849ea5888330bf11e589bf5eca5d