### PR TITLE
Fix dag api imports

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -38,3 +38,5 @@ https://github.com/MystenLabs/sui/releases
 * 22-05-24: [0.3.0](https://github.com/MystenLabs/sui/releases/tag/devnet-0.3.0-rc)
 * 22-05-12: [0.2.0](https://medium.com/mysten-labs/sui-release-notes-v0-2-0-7b377e2bf01)
 * 22-05-05: [0.1.0 (Sui Devnet launch)](https://medium.com/mysten-labs/sui-devnet-public-release-a2be304ff36b)
+
+* 25-06-13: [1.50.1-dag](https://github.com/qj0r9j0vc2/sui/releases/tag/testnet-v1.50.1-dag)

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -10,7 +10,7 @@ use std::{
     vec,
 };
 
-use consensus_config::AuthorityIndex;
+use consensus_config::{AuthorityIndex, Committee};
 use itertools::Itertools as _;
 use tokio::time::Instant;
 use tracing::{debug, error, info, trace};
@@ -38,7 +38,7 @@ use crate::{
 ///
 /// Note: DagState should be wrapped with Arc<parking_lot::RwLock<_>>, to allow
 /// concurrent access from multiple components.
-pub(crate) struct DagState {
+pub struct DagState {
     context: Arc<Context>,
 
     // The genesis blocks
@@ -546,7 +546,7 @@ impl DagState {
 
     // Retrieves the cached block within the range [start_round, end_round) from a given authority,
     // limited in total number of blocks.
-    pub(crate) fn get_cached_blocks_in_range(
+    pub fn get_cached_blocks_in_range(
         &self,
         authority: AuthorityIndex,
         start_round: Round,
@@ -814,8 +814,13 @@ impl DagState {
         self.threshold_clock.get_quorum_ts()
     }
 
-    pub(crate) fn highest_accepted_round(&self) -> Round {
+    pub fn highest_accepted_round(&self) -> Round {
         self.highest_accepted_round
+    }
+
+    /// Returns a reference to the current committee.
+    pub fn committee(&self) -> &Committee {
+        &self.context.committee
     }
 
     // Buffers a new commit in memory and updates last committed rounds.

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -67,6 +67,7 @@ pub use block::{BlockTimestampMs, TestBlock, Transaction, VerifiedBlock};
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use context::Clock;
+pub use dag_state::DagState;
 pub use network::{
     connection_monitor::{AnemoConnectionMonitor, ConnectionMonitorHandle, ConnectionStatus},
     metrics::{MetricsMakeCallbackHandler, NetworkRouteMetrics, QuinnConnectionMetrics},

--- a/crates/sui-json-rpc-api/Cargo.toml
+++ b/crates/sui-json-rpc-api/Cargo.toml
@@ -19,6 +19,7 @@ sui-json.workspace = true
 sui-json-rpc-types.workspace = true
 sui-open-rpc.workspace = true
 sui-open-rpc-macros.workspace = true
+consensus-core = { path = "../../consensus/core" }
 sui-types.workspace = true
 
 # NOTE: It's important to keep the above dependency list short.

--- a/crates/sui-json-rpc-api/src/dag.rs
+++ b/crates/sui-json-rpc-api/src/dag.rs
@@ -1,0 +1,18 @@
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::proc_macros::rpc;
+use sui_json_rpc_types::SuiDagBlock;
+use sui_open_rpc_macros::open_rpc;
+
+/// Read API for inspecting consensus DAG blocks.
+///
+/// The API is under the `suix` namespace and returns blocks across all
+/// validators for the most recent rounds.
+#[open_rpc(namespace = "suix", tag = "Consensus DAG API")]
+#[rpc(server, client, namespace = "suix")]
+pub trait DagReadApi {
+    /// Return DAG blocks for recent rounds across all validators.
+    ///
+    /// * `num_rounds` - Number of rounds to fetch, defaults to 5 if not supplied.
+    #[method(name = "getLatestDagBlocks")]
+    async fn get_latest_dag_blocks(&self, num_rounds: Option<u64>) -> RpcResult<Vec<SuiDagBlock>>;
+}

--- a/crates/sui-json-rpc-api/src/lib.rs
+++ b/crates/sui-json-rpc-api/src/lib.rs
@@ -20,6 +20,9 @@ pub use indexer::IndexerApiServer;
 pub use move_utils::MoveUtilsClient;
 pub use move_utils::MoveUtilsOpenRpc;
 pub use move_utils::MoveUtilsServer;
+pub use dag::DagReadApiClient;
+pub use dag::DagReadApiOpenRpc;
+pub use dag::DagReadApiServer;
 use once_cell::sync::Lazy;
 use prometheus::register_histogram_with_registry;
 use prometheus::Histogram;
@@ -43,6 +46,7 @@ mod governance;
 mod indexer;
 mod move_utils;
 mod read;
+mod dag;
 mod transaction_builder;
 mod write;
 

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -17,12 +17,15 @@ colored.workspace = true
 itertools.workspace = true
 tracing.workspace = true
 bcs.workspace = true
+sui-json.workspace = true
+consensus-core = { path = "../../consensus/core" }
 sui-protocol-config.workspace = true
 sui-macros.workspace = true
 sui-enum-compat-util.workspace = true
 enum_dispatch.workspace = true
 json_to_table.workspace = true
 tabled.workspace = true
+base64.workspace = true
 
 move-binary-format.workspace = true
 move-command-line-common.workspace = true
@@ -33,7 +36,6 @@ move-ir-types.workspace = true
 
 mysten-metrics.workspace = true
 sui-types.workspace = true
-sui-json.workspace = true
 sui-package-resolver.workspace = true
 
 [dev-dependencies]

--- a/crates/sui-json-rpc-types/src/lib.rs
+++ b/crates/sui-json-rpc-types/src/lib.rs
@@ -17,6 +17,7 @@ pub use sui_move::*;
 pub use sui_object::*;
 pub use sui_protocol::*;
 pub use sui_transaction::*;
+pub use sui_dag::*;
 use sui_types::base_types::ObjectID;
 
 #[cfg(test)]
@@ -35,6 +36,7 @@ mod sui_move;
 mod sui_object;
 mod sui_protocol;
 mod sui_transaction;
+mod sui_dag;
 
 pub type DynamicFieldPage = Page<DynamicFieldInfo, ObjectID>;
 /// `next_cursor` points to the last item in the page;

--- a/crates/sui-json-rpc-types/src/sui_dag.rs
+++ b/crates/sui-json-rpc-types/src/sui_dag.rs
@@ -1,0 +1,44 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use consensus_core::{BlockAPI, VerifiedBlock};
+use base64::{engine::general_purpose, Engine};
+
+/// Basic information about a DAG block.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SuiDagBlock {
+    /// Epoch when this block was produced.
+    #[schemars(with = "u64")]
+    pub epoch: u64,
+    /// Round of the block.
+    pub round: u32,
+    /// Numeric identifier of the authoring validator.
+    pub author: u32,
+    /// Base64 encoded digest of the block.
+    pub digest: String,
+    /// Timestamp in milliseconds.
+    #[schemars(with = "u64")]
+    pub timestamp_ms: u64,
+    /// Digests of parent blocks (base64 encoded).
+    pub parents: Vec<String>,
+}
+
+impl From<VerifiedBlock> for SuiDagBlock {
+    fn from(block: VerifiedBlock) -> Self {
+        SuiDagBlock {
+            epoch: block.epoch() as u64,
+            round: block.round(),
+            author: block.author().value() as u32,
+            digest: general_purpose::STANDARD.encode(block.reference().digest.as_ref()),
+            timestamp_ms: block.timestamp_ms(),
+            parents: block
+                .ancestors()
+                .iter()
+                .map(|p| {
+                    general_purpose::STANDARD.encode(p.digest.as_ref())
+                })
+                .collect(),
+        }
+    }
+}

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -58,6 +58,8 @@ sui-macros.workspace = true
 sui-transaction-builder.workspace = true
 mysten-metrics.workspace = true
 shared-crypto.workspace = true
+parking_lot.workspace = true
+consensus-core = { path = "../../consensus/core" }
 typed-store-error.workspace = true
 cached.workspace = true
 im.workspace = true

--- a/crates/sui-json-rpc/src/dag_api.rs
+++ b/crates/sui-json-rpc/src/dag_api.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::RpcModule;
+use parking_lot::RwLock;
+use consensus_core::DagState;
+use sui_open_rpc::Module;
+use sui_json_rpc_api::{DagReadApiOpenRpc, DagReadApiServer, JsonRpcMetrics};
+use sui_json_rpc_types::SuiDagBlock;
+
+use crate::{with_tracing, SuiRpcModule, error::Error};
+
+#[derive(Clone)]
+pub struct DagReadApi {
+    dag_state: Arc<RwLock<DagState>>, 
+    _metrics: Arc<JsonRpcMetrics>,
+}
+
+impl DagReadApi {
+    pub fn new(dag_state: Arc<RwLock<DagState>>, metrics: Arc<JsonRpcMetrics>) -> Self {
+        Self { dag_state, _metrics: metrics }
+    }
+}
+
+#[async_trait]
+impl DagReadApiServer for DagReadApi {
+    async fn get_latest_dag_blocks(&self, num_rounds: Option<u64>) -> RpcResult<Vec<SuiDagBlock>> {
+        with_tracing!(async move {
+            let num_rounds = num_rounds.unwrap_or(5);
+            let ds = self.dag_state.read();
+            let highest = ds.highest_accepted_round();
+            let start = highest.saturating_sub(num_rounds as u32);
+            let mut blocks = Vec::new();
+            for i in 0..ds.committee().size() {
+                let author = ds.committee().to_authority_index(i).unwrap();
+                let mut b = ds.get_cached_blocks_in_range(author, start, highest + 1, usize::MAX);
+                blocks.append(&mut b);
+            }
+            Ok(blocks.into_iter().map(SuiDagBlock::from).collect())
+        })
+    }
+}
+
+impl SuiRpcModule for DagReadApi {
+    fn rpc(self) -> RpcModule<Self> {
+        self.into_rpc()
+    }
+
+    fn rpc_doc_module() -> Module {
+        DagReadApiOpenRpc::module_doc()
+    }
+}

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -33,6 +33,7 @@ pub mod authority_state;
 mod balance_changes;
 pub mod bridge_api;
 pub mod coin_api;
+pub mod dag_api;
 pub mod error;
 pub mod governance_api;
 pub mod indexer_api;


### PR DESCRIPTION
## Summary
- expose consensus DagState publicly for DAG RPC
- update DagReadApi to call public methods on DagState
- fix missing Error import in DagReadApi
- document testnet DAG release tag

## Testing
- `cargo fmt --all` *(failed to download toolchain)*
- `cargo fmt --all -- --check` *(failed to download toolchain)*
- `cargo check -p sui-json-rpc --quiet` *(failed to download toolchain)*

------
https://chatgpt.com/codex/tasks/task_b_684a85d3caec83309382d95c288a956a