### PR TITLE
Add DAG API and fix duplicate method

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -493,10 +493,6 @@ where
         self.dag_state.clone()
     }
 
-    pub(crate) fn dag_state(&self) -> Arc<RwLock<DagState>> {
-        self.dag_state.clone()
-    }
-
     pub(crate) async fn replay_complete(&self) {
         self.commit_consumer_monitor.replay_complete().await;
     }


### PR DESCRIPTION
## Summary
- provide DagReadApi for querying consensus DAG
- model DAG blocks as `SuiDagBlock`
- clean up duplicated `dag_state` function

## Testing
- `cargo check -p consensus-core` *(failed: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_b_684e9bfeb5488330886da0d20d6aed12