### PR TITLE
Fix import path for JsonRpcMetrics

### DIFF
--- a/crates/sui-indexer/src/apis/dag_api.rs
+++ b/crates/sui-indexer/src/apis/dag_api.rs
@@ -13,13 +13,13 @@ use sui_open_rpc::Module;
 use crate::errors::client_error_to_error_object;
 
 pub(crate) struct DagReadApi {
-    client: DagReadApiClient<HttpClient>,
+    fullnode: HttpClient,
 }
 
 impl DagReadApi {
     pub fn new(fullnode_client: HttpClient) -> Self {
         Self {
-            client: DagReadApiClient::new(fullnode_client),
+            fullnode: fullnode_client,
         }
     }
 }
@@ -27,7 +27,8 @@ impl DagReadApi {
 #[async_trait]
 impl DagReadApiServer for DagReadApi {
     async fn get_latest_dag_blocks(&self, num_rounds: Option<u64>) -> RpcResult<Vec<SuiDagBlock>> {
-        self.client
+        self
+            .fullnode
             .get_latest_dag_blocks(num_rounds)
             .await
             .map_err(client_error_to_error_object)

--- a/crates/sui-indexer/src/apis/dag_api.rs
+++ b/crates/sui-indexer/src/apis/dag_api.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::http_client::HttpClient;
+use jsonrpsee::RpcModule;
+use sui_json_rpc::SuiRpcModule;
+use sui_json_rpc_api::{DagReadApiClient, DagReadApiServer};
+use sui_json_rpc_types::SuiDagBlock;
+use sui_open_rpc::Module;
+
+use crate::errors::client_error_to_error_object;
+
+pub(crate) struct DagReadApi {
+    client: DagReadApiClient<HttpClient>,
+}
+
+impl DagReadApi {
+    pub fn new(fullnode_client: HttpClient) -> Self {
+        Self {
+            client: DagReadApiClient::new(fullnode_client),
+        }
+    }
+}
+
+#[async_trait]
+impl DagReadApiServer for DagReadApi {
+    async fn get_latest_dag_blocks(&self, num_rounds: Option<u64>) -> RpcResult<Vec<SuiDagBlock>> {
+        self.client
+            .get_latest_dag_blocks(num_rounds)
+            .await
+            .map_err(client_error_to_error_object)
+    }
+}
+
+impl SuiRpcModule for DagReadApi {
+    fn rpc(self) -> RpcModule<Self> {
+        self.into_rpc()
+    }
+
+    fn rpc_doc_module() -> Module {
+        sui_json_rpc_api::DagReadApiOpenRpc::module_doc()
+    }
+}

--- a/crates/sui-indexer/src/apis/mod.rs
+++ b/crates/sui-indexer/src/apis/mod.rs
@@ -9,6 +9,7 @@ pub(crate) use move_utils::MoveUtilsApi;
 pub(crate) use read_api::ReadApi;
 pub(crate) use transaction_builder_api::TransactionBuilderApi;
 pub(crate) use write_api::WriteApi;
+pub(crate) use dag_api::DagReadApi;
 
 mod coin_api;
 mod extended_api;
@@ -18,3 +19,4 @@ mod move_utils;
 pub mod read_api;
 mod transaction_builder_api;
 mod write_api;
+mod dag_api;

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -15,8 +15,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use sui_json_rpc::ServerType;
-use sui_json_rpc::{dag_api::DagReadApi, JsonRpcMetrics, JsonRpcServerBuilder, ServerHandle};
-use std::sync::Arc;use sui_json_rpc_api::CLIENT_SDK_TYPE_HEADER;
+use sui_json_rpc::{dag_api::DagReadApi, JsonRpcServerBuilder, ServerHandle};
+use std::sync::Arc;
+use sui_json_rpc_api::{CLIENT_SDK_TYPE_HEADER, JsonRpcMetrics};
 
 use crate::apis::{
     CoinReadApi, ExtendedApi, GovernanceReadApi, IndexerApi, MoveUtilsApi, ReadApi,

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -15,13 +15,13 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use sui_json_rpc::ServerType;
-use sui_json_rpc::{dag_api::DagReadApi, JsonRpcServerBuilder, ServerHandle};
+use sui_json_rpc::{JsonRpcServerBuilder, ServerHandle};
 use std::sync::Arc;
-use sui_json_rpc_api::{CLIENT_SDK_TYPE_HEADER, JsonRpcMetrics};
+use sui_json_rpc_api::CLIENT_SDK_TYPE_HEADER;
 
 use crate::apis::{
     CoinReadApi, ExtendedApi, GovernanceReadApi, IndexerApi, MoveUtilsApi, ReadApi,
-    TransactionBuilderApi, WriteApi,
+    TransactionBuilderApi, WriteApi, DagReadApi,
 };
 use crate::indexer_reader::IndexerReader;
 use errors::IndexerError;
@@ -64,7 +64,7 @@ pub async fn build_json_rpc_server(
     builder.register_module(ReadApi::new(reader.clone()))?;
     builder.register_module(CoinReadApi::new(reader.clone()))?;
     builder.register_module(ExtendedApi::new(reader.clone()))?;
-    builder.register_module(DagReadApi::new(None, JsonRpcMetrics::global(prometheus_registry)))?;
+    builder.register_module(DagReadApi::new(http_client.clone()))?;
 
     let system_package_task =
         SystemPackageTask::new(reader.clone(), cancel.clone(), Duration::from_secs(10));


### PR DESCRIPTION
## Summary
- fix the JsonRpcMetrics import in `sui-indexer`

## Testing
- `cargo check -p sui-indexer` *(failed: could not download rust toolchain)*

------
https://chatgpt.com/codex/tasks/task_b_684e9f37c26483308ed61b57f497dc17